### PR TITLE
set light mode as default

### DIFF
--- a/src/hook/Theme.js
+++ b/src/hook/Theme.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 
 export default function useTheme() {
-    const [theme, setTheme] = useState(localStorage.theme);
+    const [theme, setTheme] = useState(localStorage.theme || 'light');
   
     useEffect(() => {
       const oldTheme = theme === 'dark' ? 'light' : 'dark';


### PR DESCRIPTION
Set light mode as default in order to prevent mismatch on first load.
This can probably be set to browser preference in future time allowing